### PR TITLE
Fix getting of the bot name and email from env variables

### DIFF
--- a/.github/workflows/gh-pages-deploy.yml
+++ b/.github/workflows/gh-pages-deploy.yml
@@ -40,15 +40,15 @@ jobs:
         add: 'data'
         branch: main
         message: "Update data: ${{ steps.date.outputs.date }}"
-        author_name: env.BOT_NAME
-        author_email: env.BOT_EMAIL
+        author_name: ${{ env.BOT_NAME }}
+        author_email: ${{ env.BOT_EMAIL }}
     - name: Upload static files to gh-pages
       uses: peaceiris/actions-gh-pages@v3
       with:
         personal_token: ${{ secrets.GH_TOKEN }}
         publish_dir: ./public
         keep_files: false
-        user_name: env.BOT_NAME
-        user_email: env.BOT_EMAIL
+        user_name: ${{ env.BOT_NAME }}
+        user_email: ${{ env.BOT_EMAIL }}
         publish_branch: gh-pages
         commit_message: "Update static pages: ${{ steps.date.outputs.date }}"


### PR DESCRIPTION
Without this change, it just uses text env.BOT_NAME  and env.BOT_EMAIL (instead of values of these variables) as bot name and email respectively:

![2021-06-08 08 42 40 github com ee2be241f9e6](https://user-images.githubusercontent.com/2442833/121129379-82e80e00-c835-11eb-9ff9-c4c94de8ca61.png)
